### PR TITLE
aggiornamento plone.event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- plone.event 2.0.0 -> 2.0.1 [mamico]
+    - fix gestione ricorrenze https://github.com/plone/plone.event/pull/23
+
 - design.plone.contenttypes 6.0.21 -> 6.1.0 [mamico]
     - Optionally add image_scales and image_field in Summary serializer. [mamico]
     - Add @@design-utils view that shows all available utility views. [cekk]

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,6 +13,7 @@ collective.feedback = 1.0.0
 collective.geolocationbehavior = 1.7.1
 collective.honeypot = 2.1
 collective.purgebyid = 1.2.0
+# XXX: non aggiornare alla 0.3.1, attendere eventualmente la 0.3.2
 collective.sentry = 0.3.0
 collective.taxonomy = 3.0.1
 collective.tiles.collection = 2.0.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,6 +7,8 @@ extends =
 version = __CURRENT_VERSION__
 
 [versions]
+# TODO: eliminare dopo l'aggiornamento alla 6.0.8
+plone.event = 2.0.1
 # agid-related products
 collective.address = 1.6
 collective.feedback = 1.0.0


### PR DESCRIPTION
fix gestione ricorrenze

da eliminare da versions.cfg dopo l'aggiornamento a plone 6.0.8 #6 