### PR TITLE
update redturtle.prenotazioni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20240201-01
+- Upgrade redturtle.prenotazioni version to 2.4.5
+  - sort_on/sort_order in restapi bookings and xlsx [mamico]
+
 ## 20240129-01
 - Upgrade design.plone.ioprenoto 1.2.2
   - Fix encoding booking_type vocab [mamico]

--- a/versions.cfg
+++ b/versions.cfg
@@ -93,7 +93,7 @@ weasyprint = 58.1
 
 # io-prenoto
 design.plone.ioprenoto = 1.2.2
-redturtle.prenotazioni = 2.4.4
+redturtle.prenotazioni = 2.4.5
 pas.plugins.jwt = 1.0a3
 pyexcel-ods3 = 0.6.1
 pyexcel-ezodf = 0.3.4


### PR DESCRIPTION
- Upgrade redturtle.prenotazioni version to 2.4.5
  - sort_on/sort_order in restapi bookings and xlsx [mamico]