### PR TITLE
allineamento versioni da iocomune.buildout

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -27,12 +27,14 @@ plone.formwidget.contenttree = 1.2.0
 
 # agid-related products
 collective.address = 1.6
-collective.exportimport = 1.7
+collective.exportimport = 1.10
 collective.feedback = 1.0.0
 collective.geolocationbehavior = 1.7.1
 collective.honeypot = 2.1
 collective.purgebyid = 1.2.2
+collective.regenv = 1.0.0rc1
 collective.sentry = 0.3.2
+collective.stats = 1.1.0
 collective.taxonomy = 3.0.1
 collective.tiles.collection = 2.0.0
 collective.venue = 4.1
@@ -59,7 +61,9 @@ iw.rejectanonymous = 1.2.7
 kitconcept.seo = 2.0.1
 openpyxl = 3.1.2
 plone.formwidget.geolocation = 2.2.1
+psutil = 5.9.5
 pycountry = 19.8.18
+PyYAML = 6.0.1
 redturtle.bandi = 1.4.3
 redturtle.faq = 1.0.1
 redturtle.filesretriever = 1.0.0


### PR DESCRIPTION
versioni di prodotti attualmente definite in iocomune.buildout, una volta fatto merge e tag le rimuovo dall'altra parte.