### PR TITLE
add new dependency for gdprcookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## ???
+
+- New dependency: collective.volto.gdprcookie
+  [cekk]
+
 ## 20240319-01
 
 - Update redturtle.prenotazioni 2.5.0 -> 2.5.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -43,6 +43,7 @@ collective.volto.cookieconsent = 1.1.1
 collective.volto.dropdownmenu = 1.3.0
 collective.volto.enhancedlinks = 1.0.1
 collective.volto.formsupport = 2.6.2
+collective.volto.gdprcookie = 1.0.2
 collective.volto.secondarymenu = 1.1.0
 collective.volto.socialsettings = 0.2.1
 collective.volto.subfooter = 1.1.0


### PR DESCRIPTION
This need to be updated with the release of redturtle.volto with this pr: https://github.com/RedTurtle/redturtle.volto/pull/104