### PR TITLE
design.plone.iocittadino 1.0.5 -> 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 20241106-01
+- design.plone.iocittadino 1.0.5 -> 1.1.0
+  - Revisione dei messaggi inviati per inviare messaggio al cambio di stato (l'api prende anche messaggio
+    aggiuntivio e allegato) [mamico]
+  - Revisione dei testi dei messaggi inviati [nicola/mamico]
+  - Aggiunto campo nel modello pratica per gestire un etsto "firma" delle email inviate [mamico]
+  - Restyling pdf [mamico]
+  - Richiede volto-io-cittadiino >= 2.4.0 sul frontend
+
 ## 20241031-01
 - design.plone.iocittadino 1.0.4 -> 1.0.5
   - Fixed radiogroup survey adapter.

--- a/versions.cfg
+++ b/versions.cfg
@@ -94,7 +94,7 @@ Products.ZMIntrospection = 1.0
 experimental.gracefulblobmissing = 2.0
 
 # io-cittadino
-design.plone.iocittadino = 1.0.5
+design.plone.iocittadino = 1.1.0
 Brotli = 1.0.9
 cssselect2 = 0.7.0
 fonttools = 4.39.3


### PR DESCRIPTION
- design.plone.iocittadino 1.0.5 -> 1.1.0
  - Revisione dei messaggi inviati per inviare messaggio al cambio di stato (l'api prende anche messaggio
    aggiuntivio e allegato) [mamico]
  - Revisione dei testi dei messaggi inviati [nicola/mamico]
  - Aggiunto campo nel modello pratica per gestire un etsto "firma" delle email inviate [mamico]
  - Restyling pdf [mamico]
  - Richiede volto-io-cittadiino >= 2.4.0 sul frontend