### PR TITLE
onceonly

### DIFF
--- a/.github/workflows/buildout.yml
+++ b/.github/workflows/buildout.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           # XXX: update setuptools for https://github.com/pypa/setuptools/pull/4856/files
-          pip instaall setuptools==75.8.2
+          pip install setuptools==75.8.2
       - name: Build
         run: |
           buildout -t 2

--- a/.github/workflows/buildout.yml
+++ b/.github/workflows/buildout.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          # XXX: update setuptools for https://github.com/pypa/setuptools/pull/4856/files
+          pip instaall setuptools==75.8.2
       - name: Build
         run: |
           buildout -t 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 20250305-01
+- design.plone.iocittadino 1.2.0 -> 1.2.1
+- design.plone.ioprenoto 1.2.9 -> 1.2.10
+  gestione onceonly ioprenoto (campi email e telefono vengono mantenuti se l'utente è autenticato
+  e iocittadino attivo)
+
 ## 20250303-01
 - design.plone.iocittadino 1.1.5 -> 1.2.0
   - TODO: quando si porta questo su ioComune va valutato se mettere nella release.md di iocittadino

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM plone/plone-backend:6.0.10.1
+FROM plone/plone-backend:6.0.14
 COPY docker/create-constraints.py docker/constraints.cfg docker/requirements.txt /app/
 COPY versions.cfg /
-RUN pip install -r https://dist.plone.org/release/6.0.10.1/requirements.txt ${PIP_PARAMS} && \
+RUN pip install -r https://dist.plone.org/release/6.0.14/requirements.txt ${PIP_PARAMS} && \
     python create-constraints.py constraints.cfg constraints.txt && \
     ./bin/pip install --ignore-requires-python -r requirements.txt -c constraints.txt ${PIP_PARAMS} && \
     find /app/lib -name LC_MESSAGES -exec chown -R plone:plone {} \;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,1 @@
-pip==24.2
-# Overrided all requirements of plone6.0.13 because of this: https://github.com/pypa/setuptools/pull/4856/files
-setuptools==75.8.2
-wheel==0.44.0
-zc.buildout==3.1.0
-
-# Windows specific down here (has to be installed here, fails in buildout)
-# Dependency of zope.sendmail:
-pywin32 ; platform_system == 'Windows'
-
-# SSL Certs on windows, because Python is missing them otherwise:
-certifi ; platform_system == 'Windows'
-
-# VSCode robotframework-lsp requires robotframework directly in venv
-robotframework==6.0.2
-# robotframework >= 6.1 is only supported with robotframwork-lsp >= 1.11.0,
-# but https://github.com/robocorp/robotframework-lsp/issues/947
+-r https://dist.plone.org/release/6.0.14/requirements.txt

--- a/versions.cfg
+++ b/versions.cfg
@@ -95,7 +95,7 @@ Products.ZMIntrospection = 1.0
 experimental.gracefulblobmissing = 2.0
 
 # io-cittadino
-design.plone.iocittadino = 1.2.0
+design.plone.iocittadino = 1.2.1
 Brotli = 1.0.9
 cssselect2 = 0.7.0
 fonttools = 4.39.3
@@ -114,7 +114,7 @@ zeep = 4.2.1
 zopfli = 0.2.2
 
 # io-prenoto
-design.plone.ioprenoto = 1.2.9
+design.plone.ioprenoto = 1.2.10
 redturtle.prenotazioni = 2.8.6
 pas.plugins.jwt = 1.0a4
 pyexcel-ods3 = 0.6.1


### PR DESCRIPTION
aggiornati design.plone.policy e ioprenoto per gestire onceonly su ioprenoto

ho ripristinato il requirements.txt puntando a quello plone e aggiungendo temporaneamente l'ìinstall di setuptools aggiornato solo nella CI