### PR TITLE
design.plone.iocittadino 1.2.3 -> 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## YYYYMMDD-VV
+- design.plone.iocittadino 1.2.3 -> 1.2.4
+  - Fix: gestione date nell'history e nel report pdf, nel serializzatore della history forzato, anche in retrocompatibilità
+    per tornare la data in iso senza millisecondi
+    [mamico]
+
 ## 20250515-01
 - redturtle.prenotazioni 2.8.6 -> 2.8.8
   - Fix get_busy_slots_in_period method to handle also borderline bookings (for example that starts inside a slot, but ends after). [cekk]

--- a/dependabot/requirements.txt
+++ b/dependabot/requirements.txt
@@ -150,7 +150,7 @@ dataflake.wsgi.bjoern==2.0
 decorator==5.1.1
 defusedxml==0.7.1
 design.plone.contenttypes==6.3.6
-design.plone.iocittadino==1.2.3
+design.plone.iocittadino==1.2.4
 design.plone.ioprenoto==1.2.10
 design.plone.policy==5.0.15
 diazo==2.0.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -100,7 +100,7 @@ Products.ZMIntrospection = 1.0
 experimental.gracefulblobmissing = 2.0
 
 # io-cittadino
-design.plone.iocittadino = 1.2.3
+design.plone.iocittadino = 1.2.4
 Brotli = 1.0.9
 cssselect2 = 0.7.0
 fonttools = 4.56.0


### PR DESCRIPTION
- design.plone.iocittadino 1.2.3 -> 1.2.4
  - Fix: gestione date nell'history e nel report pdf, nel serializzatore della history forzato, anche in retrocompatibilità
    per tornare la data in iso senza millisecondi
    [mamico]

