### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,10 +1,13 @@
 name: Create requirements.txt for dependabot
 
+permissions:
+  contents: write
+
 on:
   push:
      # TODO: fix commit permissions https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md#authentication-with-fine-grained-pat-optional
      # main:
-     pull_request:
+    pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/RedTurtle/iocomune-backend/security/code-scanning/25](https://github.com/RedTurtle/iocomune-backend/security/code-scanning/25)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow includes a step to commit and push changes to the repository, it requires `contents: write` permissions. All other permissions should be omitted or set to `read` to adhere to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, we will add it at the root level for simplicity and clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
