### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Update gh docker image and triggers
 
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
 on:
   # Triggers the workflow on releases
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RedTurtle/iocomune-backend/security/code-scanning/5](https://github.com/RedTurtle/iocomune-backend/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.
- `actions: read` for interacting with GitHub Actions artifacts.

We will add the `permissions` block at the workflow level to apply it to all jobs. If any job requires additional permissions, we will override the permissions at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
