### PR TITLE
Potential fix for code scanning alert no. 27: Checkout of untrusted code in a non-privileged context

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 name: Create requirements.txt for dependabot
 
 permissions:
-  contents: write
+  contents: read
 
 on:
   pull_request:
@@ -16,12 +16,14 @@ jobs:
   build:
     name: requirements.txt
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -53,6 +55,7 @@ jobs:
                         --sbom spdx --format json --output sbom/plone$l.spdx.json
           done
       - name: Commit and push changes
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config --global user.email "info@redturtle.it"
           git config --global user.name "RedTurtle CI BOT"

--- a/dependabot/plone60/requirements.txt
+++ b/dependabot/plone60/requirements.txt
@@ -151,7 +151,7 @@ cryptography==44.0.0
 cssselect==1.2.0
 cssselect2==0.7.0
 cssutils==2.11.0
-dataflake.wsgi.bjoern==2.0
+dataflake.wsgi.bjoern==2.2
 decorator==5.1.1
 defusedcsv==3.0.0
 defusedxml==0.7.1

--- a/dependabot/plone61/requirements.txt
+++ b/dependabot/plone61/requirements.txt
@@ -155,7 +155,7 @@ cryptography==48.0.0
 cssselect==1.4.0
 cssselect2==0.7.0
 cssutils==2.11.0
-dataflake.wsgi.bjoern==2.0
+dataflake.wsgi.bjoern==2.2
 decorator==5.3.1
 defusedcsv==3.0.0
 defusedxml==0.7.1

--- a/dependabot/plone62/requirements.txt
+++ b/dependabot/plone62/requirements.txt
@@ -153,7 +153,7 @@ cryptography==48.0.1
 cssselect==1.4.0
 cssselect2==0.7.0
 cssutils==2.11.0
-dataflake.wsgi.bjoern==2.0
+dataflake.wsgi.bjoern==2.2
 decorator==5.2.1
 defusedcsv==3.0.0
 defusedxml==0.7.1

--- a/sbom/plone60.spdx.json
+++ b/sbom/plone60.spdx.json
@@ -6,12 +6,12 @@
     "creators": [
       "Tool: sbom4python-0.12.5"
     ],
-    "created": "2026-08-01T09:56:46Z",
+    "created": "2026-08-04T08:35:21Z",
     "licenseListVersion": "3.28.0"
   },
   "name": "Python-dependabot/plone60/requirements.txt",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone60/requirements.txt-cb057c6f-dd60-406e-ad04-f140267eb966",
+  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone60/requirements.txt-4bcf0fb5-a3cc-4594-8999-40c640dda7ad",
   "packages": [
     {
       "SPDXID": "SPDXRef-1-AccessControl",
@@ -1993,7 +1993,7 @@
       "name": "PySocks",
       "versionInfo": "1.7.1",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "Person: Anorov",
+      "supplier": "NOASSERTION",
       "downloadLocation": "https://pypi.org/project/PySocks/1.7.1/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone60/requirements.txt",
@@ -2015,11 +2015,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/PySocks@1.7.1"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:anorov:PySocks:1.7.1:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -2651,8 +2646,7 @@
         }
       ],
       "licenseConcluded": "MIT",
-      "licenseDeclared": "NOASSERTION",
-      "licenseComments": "annotated-types declares MIT License which is not currently a valid SPDX License identifier or expression.",
+      "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "summary": "Reusable constraint types to use with typing.Annotated",
       "releaseDate": "2024-05-20T21:33:24Z",
@@ -5104,17 +5098,17 @@
     {
       "SPDXID": "SPDXRef-152-dataflake.wsgi.bjoern",
       "name": "dataflake.wsgi.bjoern",
-      "versionInfo": "2.0",
+      "versionInfo": "2.2",
       "primaryPackagePurpose": "APPLICATION",
       "supplier": "Person: Jens Vagelpohl",
-      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.0/#files",
+      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.2/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone60/requirements.txt",
       "homepage": "https://github.com/dataflake/dataflake.wsgi.bjoern",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "207ab73a4607089f0de21e905e372608b571fe9fa218ddb1c8d08accd943bce8"
+          "checksumValue": "32ee00b15af7fb9ec84e2331065045c4480f733d3bed2b1f9a6a35cb256d7aa2"
         }
       ],
       "licenseConcluded": "NOASSERTION",
@@ -5122,17 +5116,17 @@
       "licenseComments": "dataflake.wsgi.bjoern declares ZPL 2.1 which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "PasteDeploy entry point for the bjoern WSGI server",
-      "releaseDate": "2023-02-02T10:34:54Z",
+      "releaseDate": "2024-03-14T08:22:08Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.0"
+          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.2"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.0:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.2:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -6606,7 +6600,7 @@
       "name": "ijson",
       "versionInfo": "3.1.4",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: The International Centre for Radio Astronomy Research",
       "downloadLocation": "https://pypi.org/project/ijson/3.1.4/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone60/requirements.txt",
@@ -6627,6 +6621,11 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/ijson@3.1.4"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:the_international_centre_for_radio_astronomy_research:ijson:3.1.4:*:*:*:*:*:*:*"
         }
       ]
     },

--- a/sbom/plone61.spdx.json
+++ b/sbom/plone61.spdx.json
@@ -6,12 +6,12 @@
     "creators": [
       "Tool: sbom4python-0.12.5"
     ],
-    "created": "2026-08-01T09:58:14Z",
+    "created": "2026-08-04T08:37:55Z",
     "licenseListVersion": "3.28.0"
   },
   "name": "Python-dependabot/plone61/requirements.txt",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone61/requirements.txt-3ac0d0c6-7556-440d-aa74-b8c38bd6d5ff",
+  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone61/requirements.txt-bc5a3832-dad0-4430-bf90-66b30bde3a33",
   "packages": [
     {
       "SPDXID": "SPDXRef-1-AccessControl",
@@ -2027,7 +2027,7 @@
       "name": "PySocks",
       "versionInfo": "1.7.1",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "Person: Anorov",
+      "supplier": "NOASSERTION",
       "downloadLocation": "https://pypi.org/project/PySocks/1.7.1/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone61/requirements.txt",
@@ -2049,11 +2049,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/PySocks@1.7.1"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:anorov:PySocks:1.7.1:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -2719,8 +2714,7 @@
         }
       ],
       "licenseConcluded": "MIT",
-      "licenseDeclared": "NOASSERTION",
-      "licenseComments": "annotated-types declares MIT License which is not currently a valid SPDX License identifier or expression.",
+      "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "summary": "Reusable constraint types to use with typing.Annotated",
       "releaseDate": "2024-05-20T21:33:24Z",
@@ -5251,17 +5245,17 @@
     {
       "SPDXID": "SPDXRef-156-dataflake.wsgi.bjoern",
       "name": "dataflake.wsgi.bjoern",
-      "versionInfo": "2.0",
+      "versionInfo": "2.2",
       "primaryPackagePurpose": "APPLICATION",
       "supplier": "Person: Jens Vagelpohl",
-      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.0/#files",
+      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.2/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone61/requirements.txt",
       "homepage": "https://github.com/dataflake/dataflake.wsgi.bjoern",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "207ab73a4607089f0de21e905e372608b571fe9fa218ddb1c8d08accd943bce8"
+          "checksumValue": "32ee00b15af7fb9ec84e2331065045c4480f733d3bed2b1f9a6a35cb256d7aa2"
         }
       ],
       "licenseConcluded": "NOASSERTION",
@@ -5269,17 +5263,17 @@
       "licenseComments": "dataflake.wsgi.bjoern declares ZPL 2.1 which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "PasteDeploy entry point for the bjoern WSGI server",
-      "releaseDate": "2023-02-02T10:34:54Z",
+      "releaseDate": "2024-03-14T08:22:08Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.0"
+          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.2"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.0:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.2:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -6788,7 +6782,7 @@
       "name": "ijson",
       "versionInfo": "3.1.4",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: The International Centre for Radio Astronomy Research",
       "downloadLocation": "https://pypi.org/project/ijson/3.1.4/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone61/requirements.txt",
@@ -6809,6 +6803,11 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/ijson@3.1.4"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:the_international_centre_for_radio_astronomy_research:ijson:3.1.4:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -11358,33 +11357,19 @@
       "name": "plone.memoize",
       "versionInfo": "3.0.5",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "Person: Plone Foundation",
+      "supplier": "NOASSERTION",
       "downloadLocation": "https://pypi.org/project/plone.memoize/3.0.5/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone61/requirements.txt",
-      "homepage": "https://pypi.org/project/plone.memoize",
-      "checksums": [
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "7d817de7ec19bf27b31bae3528bf3dd6e522d38777e59bf42c6c3fa3f03a0e2e"
-        }
-      ],
-      "licenseConcluded": "BSD-3-Clause",
+      "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
-      "licenseComments": "plone.memoize declares BSD which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
-      "summary": "Decorators for caching the values of functions and methods",
-      "releaseDate": "2026-03-16T15:56:14Z",
+      "releaseDate": "2025-01-24T11:40:39Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/plone.memoize@3.0.5"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:plone_foundation:plone.memoize:3.0.5:*:*:*:*:*:*:*"
         }
       ]
     },

--- a/sbom/plone62.spdx.json
+++ b/sbom/plone62.spdx.json
@@ -6,12 +6,12 @@
     "creators": [
       "Tool: sbom4python-0.12.5"
     ],
-    "created": "2026-08-01T09:59:26Z",
+    "created": "2026-08-04T08:40:05Z",
     "licenseListVersion": "3.28.0"
   },
   "name": "Python-dependabot/plone62/requirements.txt",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone62/requirements.txt-78bcb106-2727-4bc8-b800-6e64f381b544",
+  "documentNamespace": "http://spdx.org/spdxdocs/Python-dependabot/plone62/requirements.txt-d6e0f34a-c0c9-48a0-ac96-effeb5cc5fb0",
   "packages": [
     {
       "SPDXID": "SPDXRef-1-AccessControl",
@@ -2027,7 +2027,7 @@
       "name": "PySocks",
       "versionInfo": "1.7.1",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "Person: Anorov",
+      "supplier": "NOASSERTION",
       "downloadLocation": "https://pypi.org/project/PySocks/1.7.1/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone62/requirements.txt",
@@ -2049,11 +2049,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/PySocks@1.7.1"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:anorov:PySocks:1.7.1:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -2719,8 +2714,7 @@
         }
       ],
       "licenseConcluded": "MIT",
-      "licenseDeclared": "NOASSERTION",
-      "licenseComments": "annotated-types declares MIT License which is not currently a valid SPDX License identifier or expression.",
+      "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "summary": "Reusable constraint types to use with typing.Annotated",
       "releaseDate": "2024-05-20T21:33:24Z",
@@ -5182,17 +5176,17 @@
     {
       "SPDXID": "SPDXRef-154-dataflake.wsgi.bjoern",
       "name": "dataflake.wsgi.bjoern",
-      "versionInfo": "2.0",
+      "versionInfo": "2.2",
       "primaryPackagePurpose": "APPLICATION",
       "supplier": "Person: Jens Vagelpohl",
-      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.0/#files",
+      "downloadLocation": "https://pypi.org/project/dataflake.wsgi.bjoern/2.2/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone62/requirements.txt",
       "homepage": "https://github.com/dataflake/dataflake.wsgi.bjoern",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "207ab73a4607089f0de21e905e372608b571fe9fa218ddb1c8d08accd943bce8"
+          "checksumValue": "32ee00b15af7fb9ec84e2331065045c4480f733d3bed2b1f9a6a35cb256d7aa2"
         }
       ],
       "licenseConcluded": "NOASSERTION",
@@ -5200,17 +5194,17 @@
       "licenseComments": "dataflake.wsgi.bjoern declares ZPL 2.1 which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "PasteDeploy entry point for the bjoern WSGI server",
-      "releaseDate": "2023-02-02T10:34:54Z",
+      "releaseDate": "2024-03-14T08:22:08Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.0"
+          "referenceLocator": "pkg:pypi/dataflake.wsgi.bjoern@2.2"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.0:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:jens_vagelpohl:dataflake.wsgi.bjoern:2.2:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -6345,34 +6339,34 @@
     {
       "SPDXID": "SPDXRef-190-grpcio-tools",
       "name": "grpcio-tools",
-      "versionInfo": "1.75.1",
+      "versionInfo": "1.81.0",
       "primaryPackagePurpose": "APPLICATION",
       "supplier": "Person: grpc",
-      "downloadLocation": "https://pypi.org/project/grpcio-tools/1.75.1/#files",
+      "downloadLocation": "https://pypi.org/project/grpcio-tools/1.81.0/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone62/requirements.txt",
       "homepage": "https://grpc.io",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "ae0f04d5ec8b8e13476bf516a08fc1de4e58c6bf79f99123a6b964ca7d02c790"
+          "checksumValue": "ffb1e507f9849ee013473f732b1ca5d732457f9b1d0d298efe8a77c33bb65d3a"
         }
       ],
       "licenseConcluded": "Apache-2.0",
       "licenseDeclared": "Apache-2.0",
       "copyrightText": "NOASSERTION",
       "summary": "Protobuf code generator for gRPC",
-      "releaseDate": "2025-09-26T09:07:44Z",
+      "releaseDate": "2026-06-01T05:56:38Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/grpcio-tools@1.75.1"
+          "referenceLocator": "pkg:pypi/grpcio-tools@1.81.0"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:grpc:grpcio-tools:1.75.1:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:grpc:grpcio-tools:1.81.0:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -6846,7 +6840,7 @@
       "name": "ijson",
       "versionInfo": "3.1.4",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "NOASSERTION",
+      "supplier": "Organization: The International Centre for Radio Astronomy Research",
       "downloadLocation": "https://pypi.org/project/ijson/3.1.4/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone62/requirements.txt",
@@ -6867,6 +6861,11 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/ijson@3.1.4"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:the_international_centre_for_radio_astronomy_research:ijson:3.1.4:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -11539,19 +11538,33 @@
       "name": "plone.portlet.collection",
       "versionInfo": "5.0.1",
       "primaryPackagePurpose": "APPLICATION",
-      "supplier": "NOASSERTION",
+      "supplier": "Person: Plone Foundation",
       "downloadLocation": "https://pypi.org/project/plone.portlet.collection/5.0.1/#files",
       "filesAnalyzed": false,
       "packageFileName": "dependabot/plone62/requirements.txt",
+      "homepage": "https://pypi.org/project/plone.portlet.collection/",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "84496d01f02fdb6bd4b43b142356853b6b85e01578d2d399e128a069b049889d"
+        }
+      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
+      "licenseComments": "plone.portlet.collection declares GPL version 2 which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
-      "releaseDate": "2023-02-02T12:19:37Z",
+      "summary": "A portlet that fetches results from a collection",
+      "releaseDate": "2026-06-26T08:32:24Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:pypi/plone.portlet.collection@5.0.1"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:a:plone_foundation:plone.portlet.collection:5.0.1:*:*:*:*:*:*:*"
         }
       ]
     },


### PR DESCRIPTION
Potential fix for [https://github.com/RedTurtle/iocomune-backend/security/code-scanning/27](https://github.com/RedTurtle/iocomune-backend/security/code-scanning/27)

General fix: separate untrusted PR processing from privileged write operations, or at minimum gate privileged steps so they never run for untrusted PRs (notably forks), and avoid checking out PR head refs when not required.

Best minimal fix in this file without changing core functionality:
1. Keep build/check steps on PR code.
2. Restrict the commit/push step so it runs only for trusted, same-repo PRs (`github.event.pull_request.head.repo.full_name == github.repository`).
3. Use least privilege by setting workflow `permissions` to `contents: read`, then elevate only the commit job/step context with job-level `permissions: contents: write`.
4. Prefer checking out by PR head SHA (`github.event.pull_request.head.sha`) instead of branch ref to avoid ref ambiguity/races.

Edits are all in `.github/workflows/dependabot.yml`:
- Top-level `permissions` block.
- `jobs.build` to add job-level permissions.
- Checkout step `ref`.
- Commit/push step `if` guard.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
